### PR TITLE
remove unused property from transfer.xml

### DIFF
--- a/src/FondOfSpryker/Shared/EnhancedEcommerceCheckoutConnector/Transfer/enhanced_ecommerce_checkout_connector.transfer.xml
+++ b/src/FondOfSpryker/Shared/EnhancedEcommerceCheckoutConnector/Transfer/enhanced_ecommerce_checkout_connector.transfer.xml
@@ -9,7 +9,6 @@
         <property name="eventAction" type="string"/>
         <property name="eventLabel" type="string"/>
         <property name="ecommerce" type="array"/>
-        <property name="ecCheckoutOption" type="array"/>
     </transfer>
 
     <transfer name="EnhancedEcommerceCheckout">

--- a/src/FondOfSpryker/Yves/EnhancedEcommerceCheckoutConnector/Converter/IntegerToDecimalConverter.php
+++ b/src/FondOfSpryker/Yves/EnhancedEcommerceCheckoutConnector/Converter/IntegerToDecimalConverter.php
@@ -24,6 +24,6 @@ class IntegerToDecimalConverter implements IntegerToDecimalConverterInterface
             ));
         }
 
-        return (float)bcdiv($value, static::PRICE_PRECISION, 2);
+        return (float)bcdiv(strval($value), static::PRICE_PRECISION, 2);
     }
 }

--- a/src/FondOfSpryker/Yves/EnhancedEcommerceCheckoutConnector/Dependency/EnhancedEcommerceCheckoutConnectorToStoreClientBridge.php
+++ b/src/FondOfSpryker/Yves/EnhancedEcommerceCheckoutConnector/Dependency/EnhancedEcommerceCheckoutConnectorToStoreClientBridge.php
@@ -13,7 +13,7 @@ class EnhancedEcommerceCheckoutConnectorToStoreClientBridge implements EnhancedE
     protected $storeClient;
 
     /**
-     * @param \Spryker\Shared\Kernel\Store $store
+     * @param \Spryker\Client\Store\StoreClientInterface $storeClient
      */
     public function __construct(StoreClientInterface $storeClient)
     {

--- a/src/FondOfSpryker/Yves/EnhancedEcommerceCheckoutConnector/EnhancedEcommerceCheckoutConnectorFactory.php
+++ b/src/FondOfSpryker/Yves/EnhancedEcommerceCheckoutConnector/EnhancedEcommerceCheckoutConnectorFactory.php
@@ -102,7 +102,7 @@ class EnhancedEcommerceCheckoutConnectorFactory extends AbstractFactory
     }
 
     /**
-     * @return \FondOfSpryker\Yves\EnhancedEcommerceCheckoutConnector\Dependency\EnhancedEcommerceCheckoutConnectorToCartClientInterface
+     * @return \FondOfSpryker\Yves\EnhancedEcommerceCheckoutConnector\Dependency\EnhancedEcommerceCheckoutConnectorToStoreClientInterface
      */
     public function getStoreClient(): EnhancedEcommerceCheckoutConnectorToStoreClientInterface
     {

--- a/src/FondOfSpryker/Yves/EnhancedEcommerceCheckoutConnector/Renderer/PaymentSelectionRenderer.php
+++ b/src/FondOfSpryker/Yves/EnhancedEcommerceCheckoutConnector/Renderer/PaymentSelectionRenderer.php
@@ -80,7 +80,7 @@ class PaymentSelectionRenderer implements EnhancedEcommerceRendererInterface
             ->setEventCategory(ModuleConstants::EVENT_CATEGORY)
             ->setEventAction(ModuleConstants::EVENT_ACTION_CHECKOUT_OPTION)
             ->setEventLabel(ModuleConstants::STEP_PAYMENT_SELECTION)
-            ->setEcCheckoutOption(['checkout_option' => $this->createEnhancedEcommerceCheckoutTransfer()->toArray(true, true)]);
+            ->setEcommerce(['checkout_option' => $this->createEnhancedEcommerceCheckoutTransfer()->toArray(true, true)]);
     }
 
     /**

--- a/src/FondOfSpryker/Yves/EnhancedEcommerceCheckoutConnector/Theme/default/partials/change-payment-selection.js.twig
+++ b/src/FondOfSpryker/Yves/EnhancedEcommerceCheckoutConnector/Theme/default/partials/change-payment-selection.js.twig
@@ -4,7 +4,7 @@ jQuery(document).ready(function (e) {
         availablePaymentProvider = {{ paymentProvider|json_encode|raw }}
         payment = availablePaymentProvider[jQuery(this).val()];
 
-        eecLayer['ecCheckoutOption']['checkout_option']['actionField']['option'] = payment;
+        eecLayer['ecommerce']['checkout_option']['actionField']['option'] = payment;
 
         window.dataLayer.push(eecLayer);
     });

--- a/tests/FondOfSpryker/Yves/EnhancedEcommerceCheckoutConnector/EnhancedEcommerceCheckoutConnectorDependencyProviderTest.php
+++ b/tests/FondOfSpryker/Yves/EnhancedEcommerceCheckoutConnector/EnhancedEcommerceCheckoutConnectorDependencyProviderTest.php
@@ -13,7 +13,7 @@ class EnhancedEcommerceCheckoutConnectorDependencyProviderTest extends Unit
     protected $containerMock;
 
     /**
-     * @var \FondOfSpryker\Yves\GoogleTagManagerQuoteConnector\GoogleTagManagerQuoteConnectorDependencyProvider
+     * @var \FondOfSpryker\Yves\EnhancedEcommerceCheckoutConnector\EnhancedEcommerceCheckoutConnectorDependencyProvider
      */
     protected $dependencyProvider;
 


### PR DESCRIPTION
the empty field must be removed from the transfer object, otherwise it will be rendered as an empty array in the datalayer.